### PR TITLE
Include merge messages to prevent missing [no-release] tags

### DIFF
--- a/.azure-templates/steps/cd/set-skip-release-variable.yml
+++ b/.azure-templates/steps/cd/set-skip-release-variable.yml
@@ -1,6 +1,6 @@
 steps:
 - powershell: |
-    $commitMessage = git log -1 --pretty=%B --no-merges
+    $commitMessage = git log -1 --pretty=%B
     Write-Host "Commit message = $commitMessage"
     if ($commitMessage -match '\[no-release\]') {
       Write-Host ("EXPORT {0} = {1}`n##vso[task.setvariable variable={0}]{1}" -f "SKIP_RELEASE", $True)


### PR DESCRIPTION
Currently, merged contributions/commits without the ` [no-release]` tag trigger a deployment, even though the merge message contains `[no-release]`. This PR fixes that, allowing normal contribution flow again (merger responsible for adding tag if need be.