### PR TITLE
Make EditUrl an optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/alt3bv/Docusaurus.Powershell/2?style=flat-square)](https://dev.azure.com/alt3bv/Docusaurus.Powershell/_build)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg?style=flat-square)](code-of-conduct.md)
 
-Awesome documentation for Powershell Modules.
+Showcase websites for Powershell Modules.
 
 ## Live Demo
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleBuilder = "1.*"
+    ModuleBuilder = "1.0.*"
     Pester        = "[4.7.2, 5.0)"
     platyPS       = "0.*"
 }

--- a/Source/Private/GetCustomEditUrl.ps1
+++ b/Source/Private/GetCustomEditUrl.ps1
@@ -13,18 +13,23 @@ function GetCustomEditUrl() {
     param(
         [Parameter(Mandatory = $True)][string]$Module,
         [Parameter(Mandatory = $True)][System.IO.FileSystemInfo]$MarkdownFile,
-        [Parameter(Mandatory = $True)][string]$EditUrl,
+        [Parameter(Mandatory = $False)][string]$EditUrl,
         [switch]$Monolithic
     )
 
-    # use command for non-monlithics
+    # return "false" so Docusaurus will not render the `Edit this page` button
+    if (-not($EditUrl)) {
+        return
+    }
+
+    # point to the function source file for non-monlithic modules
     if (-not($Monolithic)) {
         $command = [System.IO.Path]::GetFileNameWithoutExtension($MarkdownFile)
 
         return $EditUrl + '/' + $command + ".ps1"
     }
 
-    # use module name for monolithics
+    # point to the module source file for monolithic modules
     if (Test-Path $Module) {
         $Module = [System.IO.Path]::GetFileNameWithoutExtension($Module)
     }

--- a/Source/Private/SetMarkdownFrontMatter.ps1
+++ b/Source/Private/SetMarkdownFrontMatter.ps1
@@ -8,26 +8,27 @@ function SetMarkdownFrontMatter() {
     #>
     param(
         [Parameter(Mandatory = $True)][System.IO.FileSystemInfo]$MarkdownFile,
-        [Parameter(Mandatory = $True)][string]$CustomEditUrl
+        [Parameter(Mandatory = $False)][string]$CustomEditUrl
     )
 
-    # prepare front matter
     $powershellCommandName = [System.IO.Path]::GetFileNameWithoutExtension($markdownFile.Name)
 
-    $newFrontMatter = @(
-        "---"
-        "id: $powershellCommandName"
-        "title: $powershellCommandName"
-        "custom_edit_url: $customEditUrl"
-        "---"
-    ) | Out-String
+    # prepare front matter
+    $newFrontMatter = [System.Collections.ArrayList]::new()
+    $newFrontMatter.Add("---") | Out-Null
+    $newFrontMatter.Add("id: $($powershellCommandName)") | Out-Null
+    $newFrontMatter.Add("title: $($powershellCommandName)") | Out-Null
+    if ($EditUrl) {
+        $newFrontMatter.Add("custom_edit_url: $($EditUrl)") | Out-Null
+    }
+    $newFrontMatter.Add("---") | Out-Null
 
     # replace front matter
     $content = (Get-Content -Path $MarkdownFile.FullName -Raw).TrimEnd()
 
     $regex = "(?sm)^(---)(.+)^(---).$\n"
 
-    $newContent = $content -replace $regex, $newFrontMatter
+    $newContent = $content -replace $regex, ($newFrontMatter | Out-String)
 
     # replace file (UTF-8 without BOM)
     $fileEncoding = New-Object System.Text.UTF8Encoding $False

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -34,6 +34,8 @@ function New-DocusaurusHelp() {
         .PARAMETER EditUrl
             Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
 
+            Optional, defaults to `null`.
+
         .PARAMETER Monolithic
             Use this optional argument if the Powershell module source is monolithic.
 
@@ -53,7 +55,7 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $True)][string]$Module,
         [Parameter(Mandatory = $False)][string]$OutputFolder = "docusaurus/docs",
         [Parameter(Mandatory = $False)][string]$Sidebar = "CmdLets",
-        [Parameter(Mandatory = $True)][string]$EditUrl,
+        [Parameter(Mandatory = $False)][string]$EditUrl,
         [switch]$Monolithic
     )
 

--- a/Tests/Private/GetCustomEditUrl.Tests.ps1
+++ b/Tests/Private/GetCustomEditUrl.Tests.ps1
@@ -20,6 +20,16 @@ Describe "Private$([IO.Path]::DirectorySeparatorChar)GetCustomEditUrl" {
     ${global:dummyModuleFileItem} = Get-Item -Path $dummyModulePath
 
     # the actual tests
+    Context 'when optional -EditUrl argument is not used' {
+        $customEditUrl = InModuleScope Alt3.Docusaurus.Powershell {
+            GetCustomEditUrl -Module "DummyModule" -MarkdownFile ${global:markdownFileItem}
+        }
+
+        It "simply returns null" {
+            $customEditUrl | Should -Be $null
+        }
+    }
+
     Context 'for non-monolithic modules' {
         $customEditUrl = InModuleScope Alt3.Docusaurus.Powershell {
             GetCustomEditUrl -Module "DummyModule" -MarkdownFile ${global:markdownFileItem} -EditUrl "https://dummy.com"

--- a/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
@@ -1,7 +1,7 @@
 ---
 id: New-DocusaurusHelp
 title: New-DocusaurusHelp
-custom_edit_url: https://github.com/alt3/Docusaurus.Powershell/edit/master/Source/Public/New-DocusaurusHelp.ps1
+custom_edit_url: https://github.com/alt3/Docusaurus.Powershell/edit/master/Source/Public
 ---
 
 ## SYNOPSIS
@@ -10,7 +10,7 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 ## SYNTAX
 
 ```powershell
-New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [-EditUrl] <String>
+New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [[-EditUrl] <String>]
  [-Monolithic] [<CommonParameters>]
 ```
 
@@ -84,12 +84,14 @@ Accept wildcard characters: False
 ### -EditUrl
 Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
 
+Optional, defaults to `null`.
+
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
`-EditUrl` is now an optional argument. If not used:

- frontmatter variable `custom_edit_url` will NOT be added to the markdown
- Docusaurus will use the global `editUrl` setting and thus either:
   - **global not set:** no `Edit this Page` button
   - **global set:** edit button URL using global setting