### PR TITLE
Additional configuration arguments

### DIFF
--- a/Source/Private/SetMarkdownFrontMatter.ps1
+++ b/Source/Private/SetMarkdownFrontMatter.ps1
@@ -8,7 +8,8 @@ function SetMarkdownFrontMatter() {
     #>
     param(
         [Parameter(Mandatory = $True)][System.IO.FileSystemInfo]$MarkdownFile,
-        [Parameter(Mandatory = $False)][string]$CustomEditUrl
+        [Parameter(Mandatory = $False)][string]$CustomEditUrl,
+        [Parameter(Mandatory = $False)][string]$MetaDescription
     )
 
     $powershellCommandName = [System.IO.Path]::GetFileNameWithoutExtension($markdownFile.Name)
@@ -18,9 +19,16 @@ function SetMarkdownFrontMatter() {
     $newFrontMatter.Add("---") | Out-Null
     $newFrontMatter.Add("id: $($powershellCommandName)") | Out-Null
     $newFrontMatter.Add("title: $($powershellCommandName)") | Out-Null
+
+    if ($MetaDescription) {
+        $description = [regex]::replace($MetaDescription, '%1', $powershellCommandName)
+        $newFrontMatter.Add("description: $($description)") | Out-Null
+    }
+
     if ($EditUrl) {
         $newFrontMatter.Add("custom_edit_url: $($EditUrl)") | Out-Null
     }
+
     $newFrontMatter.Add("---") | Out-Null
 
     # replace front matter

--- a/Source/Private/SetMarkdownFrontMatter.ps1
+++ b/Source/Private/SetMarkdownFrontMatter.ps1
@@ -9,7 +9,8 @@ function SetMarkdownFrontMatter() {
     param(
         [Parameter(Mandatory = $True)][System.IO.FileSystemInfo]$MarkdownFile,
         [Parameter(Mandatory = $False)][string]$CustomEditUrl,
-        [Parameter(Mandatory = $False)][string]$MetaDescription
+        [Parameter(Mandatory = $False)][string]$MetaDescription,
+        [Parameter(Mandatory = $False)][array]$MetaKeywords
     )
 
     $powershellCommandName = [System.IO.Path]::GetFileNameWithoutExtension($markdownFile.Name)
@@ -23,6 +24,13 @@ function SetMarkdownFrontMatter() {
     if ($MetaDescription) {
         $description = [regex]::replace($MetaDescription, '%1', $powershellCommandName)
         $newFrontMatter.Add("description: $($description)") | Out-Null
+    }
+
+    if ($MetaKeywords) {
+        $newFrontMatter.Add("keywords:") | Out-Null
+        $MetaKeywords | ForEach-Object {
+            $newFrontMatter.Add("  - $($_)") | Out-Null
+        }
     }
 
     if ($EditUrl) {

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -39,6 +39,11 @@ function New-DocusaurusHelp() {
         .PARAMETER Exclude
             Optional array with command names to exclude.
 
+        .PARAMETER MetaDescription
+            Optional string that will be inserted into Docusaurus front matter to be used as `description` meta tag.
+
+            If placeholder `%1` is detected in the string, it will be replaced by the command name.
+
         .PARAMETER Monolithic
             Use this optional argument if the Powershell module source is monolithic.
 
@@ -60,6 +65,7 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $False)][string]$Sidebar = "CmdLets",
         [Parameter(Mandatory = $False)][string]$EditUrl,
         [Parameter(Mandatory = $False)][array]$Exclude = @(),
+        [Parameter(Mandatory = $False)][string]$MetaDescription,
         [switch]$Monolithic
     )
 
@@ -92,7 +98,7 @@ function New-DocusaurusHelp() {
     ForEach ($markdownFile in $markdownFiles) {
         $customEditUrl = GetCustomEditUrl -Module $Module -MarkdownFile $markdownFile -EditUrl $EditUrl -Monolithic:$Monolithic
 
-        SetMarkdownFrontMatter -MarkdownFile $markdownFile -CustomEditUrl $customEditUrl
+        SetMarkdownFrontMatter -MarkdownFile $markdownFile -CustomEditUrl $customEditUrl -MetaDescription $MetaDescription
         RemoveMarkdownHeaderOne -MarkdownFile $markdownFile
         UpdateMarkdownCodeBlocks -MarkdownFile $markdownFile
         UpdateMarkdownBackticks -MarkdownFile $markdownFile

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -36,6 +36,9 @@ function New-DocusaurusHelp() {
 
             Optional, defaults to `null`.
 
+        .PARAMETER Exclude
+            Optional array with command names to exclude.
+
         .PARAMETER Monolithic
             Use this optional argument if the Powershell module source is monolithic.
 
@@ -56,6 +59,7 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $False)][string]$OutputFolder = "docusaurus/docs",
         [Parameter(Mandatory = $False)][string]$Sidebar = "CmdLets",
         [Parameter(Mandatory = $False)][string]$EditUrl,
+        [Parameter(Mandatory = $False)][array]$Exclude = @(),
         [switch]$Monolithic
     )
 
@@ -74,7 +78,15 @@ function New-DocusaurusHelp() {
     $markdownFolder = Join-Path -Path $OutputFolder -ChildPath $Sidebar
 
     # generate PlatyPs markdown files
-    $markdownFiles = New-MarkdownHelp -Module $Module -OutputFolder $markdownFolder -Force
+    New-MarkdownHelp -Module $Module -OutputFolder $markdownFolder -Force | Out-Null
+
+    # remove excluded files
+    $Exclude | ForEach-Object {
+        Remove-Item -Path (Join-Path -Path $markdownFolder -ChildPath "$($_).md")
+    }
+
+    # process remaining files
+    $markdownFiles = Get-ChildItem -Path $markdownFolder -Filter *.md
 
     # update generated markdown file(s) to make them Docusaurus compatible
     ForEach ($markdownFile in $markdownFiles) {

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -40,9 +40,12 @@ function New-DocusaurusHelp() {
             Optional array with command names to exclude.
 
         .PARAMETER MetaDescription
-            Optional string that will be inserted into Docusaurus front matter to be used as `description` meta tag.
+            Optional string that will be inserted into Docusaurus front matter to be used as html meta tag 'description'.
 
             If placeholder `%1` is detected in the string, it will be replaced by the command name.
+
+        .PARAMETER MetaKeywords
+            Optional array of keywords inserted into Docusaurus front matter to be used as html meta tag `keywords`.
 
         .PARAMETER Monolithic
             Use this optional argument if the Powershell module source is monolithic.
@@ -66,6 +69,7 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $False)][string]$EditUrl,
         [Parameter(Mandatory = $False)][array]$Exclude = @(),
         [Parameter(Mandatory = $False)][string]$MetaDescription,
+        [Parameter(Mandatory = $False)][array]$MetaKeywords = @(),
         [switch]$Monolithic
     )
 
@@ -98,7 +102,7 @@ function New-DocusaurusHelp() {
     ForEach ($markdownFile in $markdownFiles) {
         $customEditUrl = GetCustomEditUrl -Module $Module -MarkdownFile $markdownFile -EditUrl $EditUrl -Monolithic:$Monolithic
 
-        SetMarkdownFrontMatter -MarkdownFile $markdownFile -CustomEditUrl $customEditUrl -MetaDescription $MetaDescription
+        SetMarkdownFrontMatter -MarkdownFile $markdownFile -CustomEditUrl $customEditUrl -MetaDescription $MetaDescription -MetaKeywords $MetaKeywords
         RemoveMarkdownHeaderOne -MarkdownFile $markdownFile
         UpdateMarkdownCodeBlocks -MarkdownFile $markdownFile
         UpdateMarkdownBackticks -MarkdownFile $markdownFile

--- a/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
@@ -11,7 +11,7 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 
 ```powershell
 New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [[-EditUrl] <String>]
- [-Monolithic] [<CommonParameters>]
+ [[-Exclude] <Array>] [-Monolithic] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -94,6 +94,21 @@ Aliases:
 Required: False
 Position: 4
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exclude
+Optional array with command names to exclude.
+
+```yaml
+Type: Array
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: @()
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
@@ -11,7 +11,7 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 
 ```powershell
 New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [[-EditUrl] <String>]
- [[-Exclude] <Array>] [-Monolithic] [<CommonParameters>]
+ [[-Exclude] <Array>] [[-MetaDescription] <String>] [-Monolithic] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -109,6 +109,23 @@ Aliases:
 Required: False
 Position: 5
 Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MetaDescription
+Optional string that will be inserted into Docusaurus front matter to be used as `description` meta tag.
+
+If placeholder `%1` is detected in the string, it will be replaced by the command name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
@@ -11,7 +11,8 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 
 ```powershell
 New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [[-EditUrl] <String>]
- [[-Exclude] <Array>] [[-MetaDescription] <String>] [-Monolithic] [<CommonParameters>]
+ [[-Exclude] <Array>] [[-MetaDescription] <String>] [[-MetaKeywords] <Array>] [-Monolithic]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -114,7 +115,7 @@ Accept wildcard characters: False
 ```
 
 ### -MetaDescription
-Optional string that will be inserted into Docusaurus front matter to be used as `description` meta tag.
+Optional string that will be inserted into Docusaurus front matter to be used as html meta tag 'description'.
 
 If placeholder `%1` is detected in the string, it will be replaced by the command name.
 
@@ -126,6 +127,21 @@ Aliases:
 Required: False
 Position: 6
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MetaKeywords
+Optional array of keywords inserted into Docusaurus front matter to be used as html meta tag `keywords`.
+
+```yaml
+Type: Array
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: @()
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
- commands can now be excluded by using the `-Exclude` switch
- html description meta tag can now be set by passing the `-MetaDescription` tag (using `%1% placeholder)
- html keywords meta tag can now be set by passing the `-MetaKeywords` tag