### PR TITLE
Adds new argument switches (-HideTitle and -HideTableOfContents)

### DIFF
--- a/Source/Private/SetMarkdownFrontMatter.ps1
+++ b/Source/Private/SetMarkdownFrontMatter.ps1
@@ -10,7 +10,9 @@ function SetMarkdownFrontMatter() {
         [Parameter(Mandatory = $True)][System.IO.FileSystemInfo]$MarkdownFile,
         [Parameter(Mandatory = $False)][string]$CustomEditUrl,
         [Parameter(Mandatory = $False)][string]$MetaDescription,
-        [Parameter(Mandatory = $False)][array]$MetaKeywords
+        [Parameter(Mandatory = $False)][array]$MetaKeywords,
+        [switch]$HideTitle,
+        [switch]$HideTableOfContents
     )
 
     $powershellCommandName = [System.IO.Path]::GetFileNameWithoutExtension($markdownFile.Name)
@@ -32,6 +34,8 @@ function SetMarkdownFrontMatter() {
             $newFrontMatter.Add("  - $($_)") | Out-Null
         }
     }
+    $newFrontMatter.Add("hide_title: $(if ($HideTitle) {"true"} else {"false"})") | Out-Null
+    $newFrontMatter.Add("hide_table_of_contents: $(if ($HideTableOfContents) {"true"} else {"false"})") | Out-Null
 
     if ($EditUrl) {
         $newFrontMatter.Add("custom_edit_url: $($EditUrl)") | Out-Null

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -31,11 +31,6 @@ function New-DocusaurusHelp() {
 
             Optional, defaults to `CmdLets`, case sensitive.
 
-        .PARAMETER EditUrl
-            Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
-
-            Optional, defaults to `null`.
-
         .PARAMETER Exclude
             Optional array with command names to exclude.
 
@@ -46,6 +41,21 @@ function New-DocusaurusHelp() {
 
         .PARAMETER MetaKeywords
             Optional array of keywords inserted into Docusaurus front matter to be used as html meta tag `keywords`.
+
+        .PARAMETER EditUrl
+            Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
+
+            Optional, defaults to `null`.
+
+        .PARAMETER HideTitle
+            Sets the Docusaurus front matter variable `hide_title`.
+
+            Optional, defaults to `false`.
+
+        .PARAMETER HideTableOfContents
+            Sets the Docusaurus front matter variable `hide_table_of_contents`.
+
+            Optional, defaults to `false`.
 
         .PARAMETER Monolithic
             Use this optional argument if the Powershell module source is monolithic.
@@ -66,10 +76,12 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $True)][string]$Module,
         [Parameter(Mandatory = $False)][string]$OutputFolder = "docusaurus/docs",
         [Parameter(Mandatory = $False)][string]$Sidebar = "CmdLets",
-        [Parameter(Mandatory = $False)][string]$EditUrl,
         [Parameter(Mandatory = $False)][array]$Exclude = @(),
         [Parameter(Mandatory = $False)][string]$MetaDescription,
         [Parameter(Mandatory = $False)][array]$MetaKeywords = @(),
+        [Parameter(Mandatory = $False)][string]$EditUrl,
+        [switch]$HideTitle,
+        [switch]$HideTableOfContents,
         [switch]$Monolithic
     )
 
@@ -102,7 +114,16 @@ function New-DocusaurusHelp() {
     ForEach ($markdownFile in $markdownFiles) {
         $customEditUrl = GetCustomEditUrl -Module $Module -MarkdownFile $markdownFile -EditUrl $EditUrl -Monolithic:$Monolithic
 
-        SetMarkdownFrontMatter -MarkdownFile $markdownFile -CustomEditUrl $customEditUrl -MetaDescription $MetaDescription -MetaKeywords $MetaKeywords
+        $frontMatterArgs = @{
+            MarkdownFile = $markdownFile
+            MetaDescription = $metaDescription
+            CustomEditUrl = $customEditUrl
+            MetaKeywords = $metaKeywords
+            HideTitle = $HideTitle
+            HideTableOfContents = $HideTableOfContents
+        }
+        SetMarkdownFrontMatter @frontmatterArgs
+
         RemoveMarkdownHeaderOne -MarkdownFile $markdownFile
         UpdateMarkdownCodeBlocks -MarkdownFile $markdownFile
         UpdateMarkdownBackticks -MarkdownFile $markdownFile

--- a/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/CmdLets/New-DocusaurusHelp.mdx
@@ -1,6 +1,8 @@
 ---
 id: New-DocusaurusHelp
 title: New-DocusaurusHelp
+hide_title: false
+hide_table_of_contents: false
 custom_edit_url: https://github.com/alt3/Docusaurus.Powershell/edit/master/Source/Public
 ---
 
@@ -10,9 +12,9 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 ## SYNTAX
 
 ```powershell
-New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [[-EditUrl] <String>]
- [[-Exclude] <Array>] [[-MetaDescription] <String>] [[-MetaKeywords] <Array>] [-Monolithic]
- [<CommonParameters>]
+New-DocusaurusHelp [-Module] <String> [[-OutputFolder] <String>] [[-Sidebar] <String>] [[-Exclude] <Array>]
+ [[-MetaDescription] <String>] [[-MetaKeywords] <Array>] [[-EditUrl] <String>] [-HideTitle]
+ [-HideTableOfContents] [-Monolithic] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -82,23 +84,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -EditUrl
-Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
-
-Optional, defaults to `null`.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 4
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Exclude
 Optional array with command names to exclude.
 
@@ -108,7 +93,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 4
 Default value: @()
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -125,7 +110,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -140,8 +125,59 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 6
 Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EditUrl
+Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
+
+Optional, defaults to `null`.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HideTitle
+Sets the Docusaurus front matter variable `hide_title`.
+
+Optional, defaults to `false`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HideTableOfContents
+Sets the Docusaurus front matter variable `hide_table_of_contents`.
+
+Optional, defaults to `false`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
This PR makes Docusaurus front matter variables `hide_title` and `hide_table_of_contents` explicit.

**Default values**: `false`.

```
---
id: Add-AssertionOperator
title: Add-AssertionOperator
description: Help page for the Powershell Pester "Add-AssertionOperator" command
keywords:
  - Powershell
  - Pester
  - Help
  - Documentation
hide_title: false
hide_table_of_contents: false
---
```