### PR TITLE
Adds the -VendorAgnostic switch

### DIFF
--- a/Source/Private/InitializeTempFolder.ps1
+++ b/Source/Private/InitializeTempFolder.ps1
@@ -6,14 +6,11 @@ function InitializeTempFolder() {
         .DESCRIPTION
             The temp folder is where all work is done before the enriched mdx files are copied
             to the docusaurus sidebar folder. We use this approach to support future debugging
-            as it will be near impossible to reason about bugs without looking at the initial
-            PlatyPS files, knowing which Powershell version was used etc.
-
-            We might even instruct users to send us the files when reporting issues (which
-            would require re-generating using the `-KeepTempFiles` switch).
+            as it will be near impossible to reason about bugs without looking at the PlatyPS
+            generated source files, knowing which Powershell version was used etc.
 
         .NOTES
-            Ideally we would also log used module versions for Alt3, PlatyPS and Pester.
+            Ideally, we should also log used module versions for Alt3, PlatyPS and Pester.
     #>
     param(
         [Parameter(Mandatory = $True)][string]$Path

--- a/Source/Private/NewSidebarIncludeFile.ps1
+++ b/Source/Private/NewSidebarIncludeFile.ps1
@@ -7,6 +7,7 @@ function NewSidebarIncludeFile() {
             https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-powershell-1.0/ff730948(v=technet.10)
     #>
     param(
+        [Parameter(Mandatory = $True)][string]$TempFolder,
         [Parameter(Mandatory = $True)][string]$OutputFolder,
         [Parameter(Mandatory = $True)][string]$Sidebar,
         [Parameter(Mandatory = $True)][Object]$MarkdownFiles
@@ -34,14 +35,16 @@ module.exports = [
 ];
 "@
 
-    # generate file path, convert relative output folder to absolute if needed
+    # create the temp file
+    $fileName = "docusaurus.sidebar.js"
+    $tempFile = Join-Path -Path $tempFolder -ChildPath $fileName
+    $fileEncoding = New-Object System.Text.UTF8Encoding $False
+    [System.IO.File]::WriteAllLines($tempFile, $content, $fileEncoding)
+
+    # copy to the sidebar folder, convert relative output folder to absolute if needed
     if (-Not([System.IO.Path]::IsPathRooted($OutputFolder))) {
         $outputFolder = Join-Path "$(Get-Location)" -ChildPath $OutputFolder
     }
 
-    $filePath = Join-Path -Path $outputFolder -ChildPath "docusaurus.sidebar.js"
-
-    # create the file
-    $fileEncoding = New-Object System.Text.UTF8Encoding $False
-    [System.IO.File]::WriteAllLines($filePath, $content, $fileEncoding)
+    Copy-Item -Path $tempFile -Destination (Join-Path -Path $outputFolder -ChildPath $fileName)
 }

--- a/Source/Private/ReplaceHeader1.ps1
+++ b/Source/Private/ReplaceHeader1.ps1
@@ -13,10 +13,10 @@ function ReplaceHeader1() {
 
     $content = ReadFile -MarkdownFile $MarkdownFile
 
-    $regex = '(---)\n(# .+)'
+    $regex = '(---)(\n\n|\n)(# .+)'
 
     if ($KeepHeader1) {
-        $content = $content -replace $regex, ("---`n`n" + '$2') # prepend newline (for first match only)
+        $content = $content -replace $regex, ("---`n`n" + '$3') # prepend newline (for first match only)
     } else {
         $content = $content -replace $regex, '---' # remove line (for first match only)
     }

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -103,8 +103,24 @@ function New-DocusaurusHelp() {
 
             Will point all `custom_edit_url` front matter variables to the `.psm1` file.
 
+        .PARAMETER VendorAgnostic
+            Use this switch parameter if you **do not want to use Docusaurus** but would still like
+            to benefit of the markdown-enrichment functions this module provides.
+
+            If used, the `New-GetDocusaurusHelp` command will produce the exact same markdown as
+            always but will skip the following two Docusaurus-specific steps:
+
+            - PlatyPS frontmatter will not be touched
+            - `docusaurus.sidebar.js` file will not be generated
+
+            For more information please
+            [visit this page](https://docusaurus-powershell.netlify.com/docs/faq/vendor-agnostic).
+
         .NOTES
             Please note that Docusaurus v2 is an early and alpha version, just like this module.
+
+        .LINK
+            https://docusaurus-powershell.netlify.com/
 
         .LINK
             https://v2.docusaurus.io/
@@ -125,7 +141,8 @@ function New-DocusaurusHelp() {
         [switch]$HideTitle,
         [switch]$HideTableOfContents,
         [switch]$NoPlaceHolderExamples,
-        [switch]$Monolithic
+        [switch]$Monolithic,
+        [switch]$VendorAgnostic
     )
 
     # make sure the passed module is valid
@@ -188,9 +205,13 @@ function New-DocusaurusHelp() {
             HideTableOfContents = $HideTableOfContents
         }
 
-        # transform the markdown using these steps
+        # transform the markdown using these steps (overwriting the mdx file per step)
         SetLfLineEndings -MarkdownFile $mdxFile
-        ReplaceFrontMatter @frontmatterArgs
+
+        if (-not($VendorAgnostic)) {
+            ReplaceFrontMatter @frontmatterArgs
+        }
+
         ReplaceHeader1 -MarkdownFile $mdxFile -KeepHeader1:$KeepHeader1
         ReplaceExamples -MarkdownFile $mdxFile -NoPlaceholderExamples:$NoPlaceholderExamples
         InsertPowershellMonikers -MarkdownFile $mdxFile
@@ -206,7 +227,9 @@ function New-DocusaurusHelp() {
     }
 
     # generate the `.js` file used for the docusaurus sidebar
-    NewSidebarIncludeFile -MarkdownFiles $mdxFiles -OutputFolder $sidebarFolder -Sidebar $Sidebar
+    if (-not($VendorAgnostic)) {
+        NewSidebarIncludeFile -MarkdownFiles $mdxFiles -OutputFolder $sidebarFolder -Sidebar $Sidebar
+    }
 
     # output Get-ChildItem so end-user can post-process generated files as they see fit
     Get-ChildItem -Path $sidebarFolder

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -208,9 +208,6 @@ function New-DocusaurusHelp() {
     # generate the `.js` file used for the docusaurus sidebar
     NewSidebarIncludeFile -MarkdownFiles $mdxFiles -OutputFolder $sidebarFolder -Sidebar $Sidebar
 
-    # zip temp files in case we need them
-    Compress-Archive -Path (Join-Path -Path $tempFolder -ChildPath *.*) -DestinationPath (Join-Path $tempFolder -ChildPath "$moduleName.zip")
-
     # output Get-ChildItem so end-user can post-process generated files as they see fit
     Get-ChildItem -Path $sidebarFolder
 }

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -228,7 +228,7 @@ function New-DocusaurusHelp() {
 
     # generate the `.js` file used for the docusaurus sidebar
     if (-not($VendorAgnostic)) {
-        NewSidebarIncludeFile -MarkdownFiles $mdxFiles -OutputFolder $sidebarFolder -Sidebar $Sidebar
+        NewSidebarIncludeFile -MarkdownFiles $mdxFiles -TempFolder $tempFolder -OutputFolder $sidebarFolder -Sidebar $Sidebar
     }
 
     # output Get-ChildItem so end-user can post-process generated files as they see fit

--- a/docusaurus/docs/commands/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/commands/New-DocusaurusHelp.mdx
@@ -23,7 +23,7 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 ```powershell
 New-DocusaurusHelp [-Module] <String> [[-DocsFolder] <String>] [[-Sidebar] <String>] [[-Exclude] <Array>]
  [[-EditUrl] <String>] [[-MetaDescription] <String>] [[-MetaKeywords] <Array>] [-KeepHeader1] [-HideTitle]
- [-HideTableOfContents] [-NoPlaceHolderExamples] [-Monolithic] [<CommonParameters>]
+ [-HideTableOfContents] [-NoPlaceHolderExamples] [-Monolithic] [-VendorAgnostic] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -288,6 +288,32 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -VendorAgnostic
+
+Use this switch parameter if you **do not want to use Docusaurus** but would still like
+to benefit of the markdown-enrichment functions this module provides.
+
+If used, the `New-GetDocusaurusHelp` command will produce the exact same markdown as
+always but will skip the following two Docusaurus-specific steps:
+
+- PlatyPS frontmatter will not be touched
+- `docusaurus.sidebar.js` file will not be generated
+
+For more information please
+[visit this page](https://docusaurus-powershell.netlify.com/docs/faq/vendor-agnostic).
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
@@ -302,6 +328,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 Please note that Docusaurus v2 is an early and alpha version, just like this module.
 
 ## RELATED LINKS
+
+[https://docusaurus-powershell.netlify.com/](https://docusaurus-powershell.netlify.com/)
 
 [https://v2.docusaurus.io/](https://v2.docusaurus.io/)
 

--- a/docusaurus/docs/faq/vendor-agnostic.md
+++ b/docusaurus/docs/faq/vendor-agnostic.md
@@ -4,7 +4,7 @@ title: Vendor Agnostic
 description: If you do not want to use Docusaurus, the Alt.Docusaurus.Powershell module can also produce vendor agnostic output.
 ---
 
-However much we :heart: Docusaurus, we realize it will not be a fit for everyone as users might:
+No matter how much we :heart: Docusaurus, we realize it will not be the right solution for everyone as users might:
 
 - prefer different (non-javascript) languages
 - need to maintain an existing solution

--- a/docusaurus/docs/faq/vendor-agnostic.md
+++ b/docusaurus/docs/faq/vendor-agnostic.md
@@ -1,0 +1,57 @@
+---
+id: vendor-agnostic
+title: Vendor Agnostic
+description: If you do not want to use Docusaurus, the Alt.Docusaurus.Powershell module can also produce vendor agnostic output.
+---
+
+However much we :heart: Docusaurus, we realize it will not be a fit for everyone as users might:
+
+- prefer different (non-javascript) languages
+- need to maintain an existing solution
+- simply not like the green lizard
+
+## TL;DR
+
+I want the markdown produced by this module **but I do not want to use Docusaurus**.
+
+```powershell
+New-DocusaurusHelp -Module "YourModule" -VendorAgnostic
+```
+
+## How Does It Work?
+
+By passing the `-VendorAgnostic` switch parameter this module will generate the exact same
+markdown as always but will skip two Docusaurs-specific steps during the process:
+
+1. front matter
+2. Docusaurus sidebar file
+
+### Front Matter
+
+The PlatyPS generated markdown front matter:
+
+- will not be touched
+- will need to updated/replaced (by you) to fit your needs
+- will look similar to the example below
+
+```yml
+---
+external help file: Alt3.Docusaurus.Powershell-help.xml
+Module Name: Alt3.Docusaurus.Powershell
+online version: https://docusaurus-powershell.netlify.com/
+schema: 2.0.0
+---
+```
+
+### Docusaurus Sidebar File
+
+The Docusaurus-specific `docusaurus.sidebar.js` file will not be generated.
+
+If your solution/vendor requires a similar list you will need to generate one yourself,
+perhaps using the
+[NewSideBarIncludeFile](https://github.com/alt3/Docusaurus.Powershell/blob/master/Source/Private/NewSidebarIncludeFile.ps1)
+function for inspiration.
+
+## Additional Information
+
+- Get-Help documentation for the [-VendorAgnostic](../commands/New-DocusaurusHelp#-vendoragnostic) switch parameter

--- a/docusaurus/docs/introduction.md
+++ b/docusaurus/docs/introduction.md
@@ -24,6 +24,13 @@ Some of the features you will get:
 - simplified publishing (Netlify, Github Pages)
 - dark mode
 
+## :fire: Vendor Agnostic
+
+This module can produce vendor agnostic output for cases where you
+**do not want to use Docusaurus** but do want to benefit of enriched
+markdown features like multi-line code examples.
+[Read more...](faq/vendor-agnostic)
+
 ## Early Bird
 
 Just like Docusaurus v2, this module is still in it's early stages.
@@ -32,5 +39,5 @@ things work first, then make it better.
 
 ## Feedback
 
-Suggestions, bug reports, fixes and stars welcomed at our
+Suggestions, bug reports, fixes and :star::star::star: welcomed at our
 [Github repository](https://github.com/alt3/Docusaurus.Powershell).

--- a/docusaurus/docs/introduction.md
+++ b/docusaurus/docs/introduction.md
@@ -26,9 +26,9 @@ Some of the features you will get:
 
 ## :fire: Vendor Agnostic
 
-This module can produce vendor agnostic output for cases where you
-**do not want to use Docusaurus** but do want to benefit of enriched
-markdown features like multi-line code examples.
+This module can produce vendor agnostic output for users who
+**do not want to use Docusaurus** but still want to benefit
+of advanced features like Get-Help Code Fence Detection.
 [Read more...](faq/vendor-agnostic)
 
 ## Early Bird

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -11,14 +11,15 @@ module.exports = {
     'Docs': [
       'introduction',
       'installation',
-      'usage'
+      'usage',
     ],
     'F.A.Q.': [
+      'faq/multi-line-examples',
       'faq/multiple-modules',
       'faq/monolithic-modules',
-      'faq/multi-line-examples',
       'faq/search',
       'faq/ci-cd',
+      'faq/vendor-agnostic',
     ],
     "Get-Help": commands,
   },


### PR DESCRIPTION
This module can now produce vendor agnostic markdown so:

- it can be used for other vendors/solutions
- users who do not want to use Docusaurus can still benefit of e.g. code-fencing support

Detailed description here.

```powershell
New-DocusaurusHelp -Module "YourModule" -VendorAgnostic
```