### PR TITLE
Adds -PrependMarkdown and -AppendMarkdown

### DIFF
--- a/.github/workflows/check-broken-links.md
+++ b/.github/workflows/check-broken-links.md
@@ -1,0 +1,11 @@
+---
+title: Website Contains Broken Links
+labels: housekeeping
+assignees: ''
+---
+
+The Broken Link Checker detected one or more  :coffin:  links on the pester.dev website.
+
+Please [review the results](https://github.com/pester/docs/commit/{{sha}}/checks) and resolve as appropriate.
+
+> **Pro-Tip:** use search filter `─BROKEN─` to highlight failures

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -1,0 +1,42 @@
+# -----------------------------------------------------------------------------
+# Checks the live/production website for dead links every 1st day of the month
+# and creates a Github issue (using the markdown template) if any are found.
+#
+# Please note that we are deliberately not running this action for Pull
+# Requests to prevent harassing contributors and mixing PR content.
+#
+# Uses:
+# - https://github.com/stevenvachon/broken-link-checker
+# - https://github.com/marketplace/actions/create-an-issue
+# - https://crontab.guru/#0_1_1_*_*
+#
+# To run on your local machine:
+# => npx broken-link-checker https://docusaurus-powershell.netlify.com/ --ordered --recursive
+# -----------------------------------------------------------------------------
+
+name: Broken Links Checker
+on:
+  schedule:
+    - cron:  '0 1 1 * *'
+env:
+  WEBSITE_URL: "https://docusaurus-powershell.netlify.com/"
+  ISSUE_TEMPLATE: ".github/workflows/check-broken-links.md"
+if: github.repository == 'alt3/Docusaurus.Powershell'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Run Broken Links Checker
+      run: npx broken-link-checker $WEBSITE_URL --ordered --recursive
+
+    - uses: actions/checkout@v2
+      if: failure()
+
+    - uses: JasonEtco/create-an-issue@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        filename: ${{ env.ISSUE_TEMPLATE }}
+      if: failure()

--- a/Source/Private/InsertUserMarkdown.ps1
+++ b/Source/Private/InsertUserMarkdown.ps1
@@ -1,0 +1,40 @@
+function InsertUserMarkdown() {
+    <#
+        .SYNOPSIS
+            Inserts user provided markdown directly above OR below the PlatyPS generated markdown.
+
+        .NOTES
+            Will use file content as markdown if $Markdown resolves to a file.
+    #>
+    param(
+        [Parameter(Mandatory = $True)][System.IO.FileSystemInfo]$MarkdownFile,
+        [Parameter(Mandatory = $False)][string]$Markdown,
+        [Parameter(Mandatory = $True)][ValidateSet('Prepend', 'Append')][string]$Mode
+    )
+
+    $content = ReadFile -MarkdownFile $MarkdownFile
+
+    # use file content as markdown
+    if (Test-Path $Markdown) {
+        $Markdown = Get-Content -Path $Markdown -Raw
+    }
+
+    # remove any leading or trailing newlines
+    $Markdown = $Markdown.TrimStart()
+    $Markdown = $Markdown.TrimEnd()
+
+    # convert CRLF to LF
+    $Markdown = $Markdown -replace "`r`n", "`n"
+
+    # insert user markdown
+    if ($Mode    -eq "Prepend") {
+        $regex = '(---\n\n)'
+        $content = $content -replace $regex, "---`n`n$Markdown`n`n"
+    }
+    else {
+        $content = "$content`n`n$Markdown`n`n"
+    }
+
+    # create new file
+    WriteFile -MarkdownFile $MarkdownFile -Content $content
+}

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -136,7 +136,7 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $False)][array]$Exclude = @(),
         [Parameter(Mandatory = $False)][string]$EditUrl,
         [Parameter(Mandatory = $False)][string]$MetaDescription,
-        [Parameter(Mandatory = $False)][array]$MetaKeywords = @(),
+        [Parameter(Mandatory = $False)][array]$MetaKeywords,
         [switch]$KeepHeader1,
         [switch]$HideTitle,
         [switch]$HideTableOfContents,

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -70,6 +70,16 @@ function New-DocusaurusHelp() {
         .PARAMETER MetaKeywords
             Optional array of keywords inserted into Docusaurus front matter to be used as html meta tag `keywords`.
 
+        .PARAMETER PrependMarkdown
+            Optional string containing raw markdown **OR** path to a markdown file.
+
+            Markdown will be inserted in all pages, directly above the PlatyPS generated markdown.
+
+        .PARAMETER AppendMarkdown
+            Optional string containing raw markdown **OR** path to a markdown file.
+
+            Markdown will be inserted in all pages, directly below the PlatyPS generated markdown.
+
         .PARAMETER EditUrl
             Specifies the URL prefixed to all Docusaurus `custom_edit_url` front matter variables.
 
@@ -137,6 +147,8 @@ function New-DocusaurusHelp() {
         [Parameter(Mandatory = $False)][string]$EditUrl,
         [Parameter(Mandatory = $False)][string]$MetaDescription,
         [Parameter(Mandatory = $False)][array]$MetaKeywords,
+        [Parameter(Mandatory = $False)][string]$PrependMarkdown,
+        [Parameter(Mandatory = $False)][string]$AppendMarkdown,
         [switch]$KeepHeader1,
         [switch]$HideTitle,
         [switch]$HideTableOfContents,
@@ -213,7 +225,17 @@ function New-DocusaurusHelp() {
         }
 
         ReplaceHeader1 -MarkdownFile $mdxFile -KeepHeader1:$KeepHeader1
+
+        if ($PrependMarkdown) {
+            InsertUserMarkdown -MarkdownFile $mdxFile -Markdown $PrependMarkdown -Mode "Prepend"
+        }
+
         ReplaceExamples -MarkdownFile $mdxFile -NoPlaceholderExamples:$NoPlaceholderExamples
+
+        if ($AppendMarkdown) {
+            InsertUserMarkdown -MarkdownFile $mdxFile -Markdown $AppendMarkdown -Mode "Append"
+        }
+
         InsertPowershellMonikers -MarkdownFile $mdxFile
         UnescapeSpecialChars -MarkdownFile $mdxFile
         SeparateHeaders -MarkdownFile $mdxFile

--- a/Tests/Integration/CrossVersionCodeExamples.Tests.ps1
+++ b/Tests/Integration/CrossVersionCodeExamples.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Modules Pester
 <#
     .SYNOPSIS
         This test ensures that ALL Powershell versions render the code examples as expected.

--- a/Tests/Integration/PS7NativeMultiLineCode.Tests.ps1
+++ b/Tests/Integration/PS7NativeMultiLineCode.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Modules Pester
 <#
     .SYNOPSIS
         This test ensures Powershell 7 native multi-line code examples render as expected.

--- a/Tests/Integration/PlaceholderExamples.Tests.ps1
+++ b/Tests/Integration/PlaceholderExamples.Tests.ps1
@@ -1,3 +1,4 @@
+#Requires -Modules Pester
 <#
     .SYNOPSIS
         This test ensures:

--- a/Tests/Unit/Private/GetCustomEditUrl.Tests.ps1
+++ b/Tests/Unit/Private/GetCustomEditUrl.Tests.ps1
@@ -1,3 +1,5 @@
+#Requires -Modules Pester
+
 Describe "Private$([IO.Path]::DirectorySeparatorChar)GetCustomEditUrl" {
     if (-not(Get-Module Alt3.Docusaurus.Powershell)) {
         write-host "module not loaded" -ForegroundColor yellow

--- a/docusaurus/docs/commands/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/commands/New-DocusaurusHelp.mdx
@@ -190,7 +190,7 @@ Aliases:
 
 Required: False
 Position: 7
-Default value: @()
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docusaurus/docs/commands/New-DocusaurusHelp.mdx
+++ b/docusaurus/docs/commands/New-DocusaurusHelp.mdx
@@ -22,8 +22,9 @@ Generates Get-Help documentation in Docusaurus compatible `.mdx` format.
 
 ```powershell
 New-DocusaurusHelp [-Module] <String> [[-DocsFolder] <String>] [[-Sidebar] <String>] [[-Exclude] <Array>]
- [[-EditUrl] <String>] [[-MetaDescription] <String>] [[-MetaKeywords] <Array>] [-KeepHeader1] [-HideTitle]
- [-HideTableOfContents] [-NoPlaceHolderExamples] [-Monolithic] [-VendorAgnostic] [<CommonParameters>]
+ [[-EditUrl] <String>] [[-MetaDescription] <String>] [[-MetaKeywords] <Array>] [[-PrependMarkdown] <String>]
+ [[-AppendMarkdown] <String>] [-KeepHeader1] [-HideTitle] [-HideTableOfContents] [-NoPlaceHolderExamples]
+ [-Monolithic] [-VendorAgnostic] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -190,6 +191,42 @@ Aliases:
 
 Required: False
 Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PrependMarkdown
+
+Optional string containing raw markdown **OR** path to a markdown file.
+
+Markdown will be inserted in all pages, directly above the PlatyPS generated markdown.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppendMarkdown
+
+Optional string containing raw markdown **OR** path to a markdown file.
+
+Markdown will be inserted in all pages, directly below the PlatyPS generated markdown.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
User may now insert raw markdown directly above OR below the PlatyPS generated markdown.

### Possible use cases:

- top warning: we do not accept PRs for this page (if edit button is disabled)
- footer info: generated using module version x on date etc.


