### PR TITLE
chore: rename netlify .com references to .app

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -12,7 +12,7 @@
 # - https://crontab.guru/#0_1_1_*_*
 #
 # To run on your local machine:
-# => npx broken-link-checker https://docusaurus-powershell.netlify.com/ --ordered --recursive
+# => npx broken-link-checker https://docusaurus-powershell.netlify.app/ --ordered --recursive
 # -----------------------------------------------------------------------------
 
 name: Broken Links Checker
@@ -20,7 +20,7 @@ on:
   schedule:
     - cron:  '0 1 1 * *'
 env:
-  WEBSITE_URL: "https://docusaurus-powershell.netlify.com/"
+  WEBSITE_URL: "https://docusaurus-powershell.netlify.app/"
   ISSUE_TEMPLATE: ".github/workflows/check-broken-links.md"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Docusaurus.Powershell
 
-[![Azure DevOps builds](https://img.shields.io/azure-devops/build/alt3bv/Docusaurus.Powershell/2?label=Azure%20Pipelines&style=flat-square)](https://dev.azure.com/alt3bv/Docusaurus.Powershell/_build)
-[![Netlify](https://img.shields.io/netlify/0f0b21b3-3caf-40a6-aaf8-4bc926523a0f?label=Netlify&style=flat-square)](https://app.netlify.com/sites/docusaurus-powershell/deploys/5da9a382df61220008fb04c0)
+[![Azure DevOps builds](https://img.shields.io/azure-devops/build/alt3bv/Docusaurus.Powershell/3?label=Azure%20Pipelines&style=flat-square)](https://dev.azure.com/alt3bv/Docusaurus.Powershell/_build)
+[![Netlify](https://img.shields.io/netlify/0f0b21b3-3caf-40a6-aaf8-4bc926523a0f?label=Netlify&style=flat-square)](https://app.netlify.app/sites/docusaurus-powershell/deploys/5da9a382df61220008fb04c0)
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/Alt3.Docusaurus.Powershell?style=flat-square)](https://www.powershellgallery.com/packages/Alt3.Docusaurus.Powershell)
-[![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/alt3bv/Docusaurus.Powershell/2?style=flat-square)](https://dev.azure.com/alt3bv/Docusaurus.Powershell/_build)
+[![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/alt3bv/Docusaurus.Powershell/3?style=flat-square)](https://dev.azure.com/alt3bv/Docusaurus.Powershell/_build)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg?style=flat-square)](https://www.contributor-covenant.org/version/2/0/code_of_conduct)
 
 Documentation websites for Powershell Modules.
 
 ## Live Demo
 
-https://docusaurus-powershell.netlify.com
+https://docusaurus-powershell.netlify.app
 
 ## Screenshot
 

--- a/Source/Alt3.Docusaurus.Powershell.psd1
+++ b/Source/Alt3.Docusaurus.Powershell.psd1
@@ -22,7 +22,7 @@
     Description = '
 Awesome documentation for Powershell Modules.
 
-Live demo at https://docusaurus-powershell.netlify.com/
+Live demo at https://docusaurus-powershell.netlify.app/
 '
 
     # Minimum version of the Windows PowerShell engine required by this module

--- a/Source/Public/New-DocusaurusHelp.ps1
+++ b/Source/Public/New-DocusaurusHelp.ps1
@@ -124,13 +124,13 @@ function New-DocusaurusHelp() {
             - `docusaurus.sidebar.js` file will not be generated
 
             For more information please
-            [visit this page](https://docusaurus-powershell.netlify.com/docs/faq/vendor-agnostic).
+            [visit this page](https://docusaurus-powershell.netlify.app/docs/faq/vendor-agnostic).
 
         .NOTES
             Please note that Docusaurus v2 is an early and alpha version, just like this module.
 
         .LINK
-            https://docusaurus-powershell.netlify.com/
+            https://docusaurus-powershell.netlify.app/
 
         .LINK
             https://v2.docusaurus.io/

--- a/Source/en-US/aboutAlt3.Docusaurus.Powershell.help.txt
+++ b/Source/en-US/aboutAlt3.Docusaurus.Powershell.help.txt
@@ -4,7 +4,7 @@ TOPIC
 SHORT DESCRIPTION
     Awesome documentation for Powershell Modules.
 
-    Live demo at https://docusaurus-powershell.netlify.com/
+    Live demo at https://docusaurus-powershell.netlify.app/
 
 LONG DESCRIPTION
     The New-DocusaurusHelp cmdlet generates Get-Help documentation in Docusaurus

--- a/docs/commands/New-DocusaurusHelp.mdx
+++ b/docs/commands/New-DocusaurusHelp.mdx
@@ -337,7 +337,7 @@ always but will skip the following two Docusaurus-specific steps:
 - `docusaurus.sidebar.js` file will not be generated
 
 For more information please
-[visit this page](https://docusaurus-powershell.netlify.com/docs/faq/vendor-agnostic).
+[visit this page](https://docusaurus-powershell.netlify.app/docs/faq/vendor-agnostic).
 
 ```yaml
 Type: SwitchParameter
@@ -366,7 +366,7 @@ Please note that Docusaurus v2 is an early and alpha version, just like this mod
 
 ## RELATED LINKS
 
-[https://docusaurus-powershell.netlify.com/](https://docusaurus-powershell.netlify.com/)
+[https://docusaurus-powershell.netlify.app/](https://docusaurus-powershell.netlify.app/)
 
 [https://v2.docusaurus.io/](https://v2.docusaurus.io/)
 

--- a/docs/faq/vendor-agnostic.md
+++ b/docs/faq/vendor-agnostic.md
@@ -38,7 +38,7 @@ The PlatyPS generated markdown front matter:
 ---
 external help file: Alt3.Docusaurus.Powershell-help.xml
 Module Name: Alt3.Docusaurus.Powershell
-online version: https://docusaurus-powershell.netlify.com/
+online version: https://docusaurus-powershell.netlify.app/
 schema: 2.0.0
 ---
 ```

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@
 module.exports = {
   title: 'Docusaurus.Powershell',
   tagline: 'Documentation websites for Powershell Modules',
-  url: 'https://docusaurus-powershell.netlify.com/',
+  url: 'https://docusaurus-powershell.netlify.app/',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
   organizationName: 'alt3', // Usually your GitHub org/user name.


### PR DESCRIPTION

> Starting April 14, 2020, sites without a custom domain are being moved from your-site.netlify.com to your-site.netlify.app.   New websites without custom domains will also have URLs ending with netlify.app, unless you specify a custom domain. 