### PR TITLE
fix: -EditUrl now returns 'null' string as is

### DIFF
--- a/Source/Private/GetCustomEditUrl.ps1
+++ b/Source/Private/GetCustomEditUrl.ps1
@@ -7,6 +7,7 @@ function GetCustomEditUrl() {
             Generates a URL pointing to the Powershell source file that was used to generate the markdown file.
 
         .NOTES
+            - passing string `null` will return string `null`
             - URLs for non-monolithic modules point to a .ps1 file with same name as the markdown file
             - URLs for monolithic modules will always point to a .psm1 with same name as passed module
     #>
@@ -18,12 +19,17 @@ function GetCustomEditUrl() {
     )
 
     # return "false" so Docusaurus will not render the `Edit this page` button
-    if (-not($EditUrl)) {
+    if (-not $EditUrl) {
         return
     }
 
+    # if string "null" was passed explicitely, return as-is
+    if ($EditUrl -eq "null") {
+        return "null"
+    }
+
     # point to the function source file for non-monlithic modules
-    if (-not($Monolithic)) {
+    if (-not $Monolithic) {
         $command = [System.IO.Path]::GetFileNameWithoutExtension($MarkdownFile)
 
         return $EditUrl + '/' + $command + ".ps1"

--- a/Tests/Unit/Private/GetCustomEditUrl.Tests.ps1
+++ b/Tests/Unit/Private/GetCustomEditUrl.Tests.ps1
@@ -36,6 +36,16 @@ Describe "Private$([IO.Path]::DirectorySeparatorChar)GetCustomEditUrl" {
         }
     }
 
+    Context 'when "null" is passed' {
+        $customEditUrl = InModuleScope Alt3.Docusaurus.Powershell {
+            GetCustomEditUrl -Module "DummyModule" -MarkdownFile ${global:markdownFileItem} -EditUrl "null"
+        }
+
+        It "return the string 'null'" {
+            $customEditUrl | Should -Be "null"
+        }
+    }
+
     Context 'for non-monolithic modules' {
         $customEditUrl = InModuleScope Alt3.Docusaurus.Powershell {
             GetCustomEditUrl -Module "DummyModule" -MarkdownFile ${global:markdownFileItem} -EditUrl "https://dummy.com"


### PR DESCRIPTION
This solves an issue with `custom_edit_url` returning e.g. `null/Should.ps1`