### PR TITLE
Fix commit link in release notes + switch to ubuntu-latest

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
       strategy:
         matrix:
           Linux:
-            vmImage: 'ubuntu-16.04'
+            vmImage: 'ubuntu-latest'
           MacOS:
             vmImage: 'macOS-10.14'
           Windows:

--- a/.azure-templates/jobs/cd/github-create-release.yml
+++ b/.azure-templates/jobs/cd/github-create-release.yml
@@ -145,7 +145,7 @@ jobs:
                 return
             }
 
-            $hashLink = "[$shortHash]($env:GITHUB_REPO_URL/$hash)"
+            $hashLink = "[$shortHash]($env:GITHUB_REPO_URL/commit/$hash)"
             $authorLink = "[$author](https://github.com/$author)"
 
             $markdownChangeLog += "`n- $message ($authorLink in $hashLink)"


### PR DESCRIPTION
- commit links in the Github Release Notes were broken, added `/commit/` to the URL
- replaced deprecated Azure image `ubuntu-16.04` with `ubuntu-latest` due to:

> ##[warning]Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details, see https://github.com/actions/virtual-environments/issues/3287.