### PR TITLE
Install gitversion for publish step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,6 @@ jobs:
       uses: gittools/actions/gitversion/setup@v0.9.7
       with:
         versionSpec: '5.x'
-
-    # - name: GitVersion
-    #   id: gitversion
-    #   uses: PoshCode/Actions/gitversion@v1
-
     - name: Install-RequiredModules
       uses: PoshCode/Actions/install-requiredmodules@v1
     - name: Build Module
@@ -107,6 +102,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.7
+      with:
+        versionSpec: '5.x'
 
     - name: Download Build Output
       uses: actions/download-artifact@v2


### PR DESCRIPTION
Since we are no longer using "cached" gitversion from PoshCode we need to re-install gitversion for this stage.