### PR TITLE
Re-enable CI push trigger and prevent builds happening twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 env:
   MODULE_NAME: Alt3.Docusaurus.Powershell


### PR DESCRIPTION
Trigger CI build on either pull request or push [as explained here](https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/2):

> This will prevent builds from happening twice when somebody opens a pull request against master and then pushes updates to their branch.