### PR TITLE
Move temp-file deletion for integration tests to Bootstrap

### DIFF
--- a/Tests/Integration/Bootstrap.ps1
+++ b/Tests/Integration/Bootstrap.ps1
@@ -27,3 +27,8 @@ $test = @{
 if (Get-Module -Name "TestModule") {
     Remove-Module -Name "TestModule" -Force -Verbose:$False
 }
+
+# remove any previous folders in $env:Temp
+if ((Get-Module Alt3.Docusaurus.PowerShell) -and (Test-Path -Path $test.TempFolder)) {
+    Remove-Item $test.TempFolder -Recurse -Force
+}

--- a/Tests/Integration/CrossVersionCodeExamples/Integration.Tests.ps1
+++ b/Tests/Integration/CrossVersionCodeExamples/Integration.Tests.ps1
@@ -34,9 +34,3 @@ Describe "Integration Test to ensure all supported Code Example variants render 
         $generatedMdx | Should -BeExactly $expectedMdx
     }
 }
-
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-#        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/CrossVersionCodeExamples/README.md
+++ b/Tests/Integration/CrossVersionCodeExamples/README.md
@@ -4,6 +4,6 @@ This test assures:
 
 - That various `Get-Help` examples render identically on **all** PowerShell versions
 
-Additional information:
+## Additional information:
 
 - Logic described at https://github.com/alt3/Docusaurus.PowerShell/issues/14#issuecomment-568552556

--- a/Tests/Integration/IndentLineWithOpeningBracket/Integration.Tests.ps1
+++ b/Tests/Integration/IndentLineWithOpeningBracket/Integration.Tests.ps1
@@ -34,9 +34,3 @@ Describe "Integration Test to ensure all supported Code Example variants render 
         $generatedMdx | Should -BeExactly $expectedMdx
     }
 }
-
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-#        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/IndentLineWithOpeningBracket/README.md
+++ b/Tests/Integration/IndentLineWithOpeningBracket/README.md
@@ -9,6 +9,8 @@ This test ensures that this function:
 - By comparing indentation of the line below
 - And recalculating indentation if things are amiss
 
+## Why?
+
 Required because PlatyPS sometimes gets things wrong when parsing complex code
 examples like the example below where the line with `It` should have been indented.
 
@@ -40,7 +42,7 @@ examples like the example below where the line with `It` should have been indent
 
 ```
 
-Addtional information:
+## Additional information:
 
 - https://github.com/pester/Pester/issues/2195
 - Link to regex in function [source file](https://github.com/alt3/Docusaurus.PowerShell/blob/main/Source/Private/IndentLineWithOpeningBracket.ps1#L17)

--- a/Tests/Integration/PlaceholderExamples/Integration.Tests.ps1
+++ b/Tests/Integration/PlaceholderExamples/Integration.Tests.ps1
@@ -46,9 +46,3 @@ Describe "Integration Test for PlatyPS generated placeholder examples" {
         $generatedMdxWithoutPlaceholders | Should -BeExactly $expectedMdxWithoutPlaceholders
     }
 }
-
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/PowerShell7NativeMultiLineCode/Integration.Tests.ps1
+++ b/Tests/Integration/PowerShell7NativeMultiLineCode/Integration.Tests.ps1
@@ -36,9 +36,3 @@ Describe "Integration Test to ensure PowerShell 7 Native Multi-Line Code Example
         $generatedMdx | Should -BeExactly $expectedMdx
     }
 }
-
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/PowerShell7NativeMultiLineCode/README.md
+++ b/Tests/Integration/PowerShell7NativeMultiLineCode/README.md
@@ -4,7 +4,7 @@ This test ensures:
 
 - That PowerShell 7 "native multi-line code examples" render as expected
 
-Additional information:
+## Additional information:
 
 - https://docusaurus-powershell.netlify.app/docs/faq/multi-line-examples#powershell-7-native-multi-lines
 - https://github.com/PowerShell/platyPS/issues/180#issuecomment-568877700

--- a/Tests/Integration/RemoveBlankLinesAboveClosingBracket/Integration.Tests.ps1
+++ b/Tests/Integration/RemoveBlankLinesAboveClosingBracket/Integration.Tests.ps1
@@ -34,9 +34,3 @@ Describe "Integration Test to ensure all supported Code Example variants render 
         $generatedMdx | Should -BeExactly $expectedMdx
     }
 }
-
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-#        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/RemoveBlankLinesAboveClosingBracket/README.md
+++ b/Tests/Integration/RemoveBlankLinesAboveClosingBracket/README.md
@@ -4,6 +4,8 @@ This test ensures that this function:
 
 - Removes blank line(s) below lines ending with an opening curly bracket
 
+## Why?
+
 Required because PlatyPS sometimes gets things wrong when parsing complex code
 examples like the example below:
 
@@ -16,6 +18,6 @@ examples like the example below:
     ```
 ```
 
-Addtional information:
+## Additional information:
 
 - Link to regex in function [source file](https://github.com/alt3/Docusaurus.PowerShell/blob/main/Source/Private/RemoveEmptyLinesBelowOpeningBracket.ps1#L10)

--- a/Tests/Integration/RemoveBlankLinesBelowOpeningBracket/Integration.Tests.ps1
+++ b/Tests/Integration/RemoveBlankLinesBelowOpeningBracket/Integration.Tests.ps1
@@ -34,9 +34,3 @@ Describe "Integration Test to ensure all supported Code Example variants render 
         $generatedMdx | Should -BeExactly $expectedMdx
     }
 }
-
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-#        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/RemoveBlankLinesBelowOpeningBracket/README.md
+++ b/Tests/Integration/RemoveBlankLinesBelowOpeningBracket/README.md
@@ -4,6 +4,8 @@ This test ensures that this function:
 
 - Removes blank line(s) below lines ending with an opening curly bracket
 
+## Why?
+
 Required because PlatyPS sometimes gets things wrong when parsing complex code
 examples like the example below:
 
@@ -16,6 +18,6 @@ examples like the example below:
     ```
 ```
 
-Addtional information:
+## Additional information:
 
 - Link to regex in function [source file](https://github.com/alt3/Docusaurus.PowerShell/blob/main/Source/Private/RemoveEmptyLinesBelowOpeningBracket.ps1#L10)

--- a/Tests/Integration/SeparateMarkdownHeadings/Integration.Tests.ps1
+++ b/Tests/Integration/SeparateMarkdownHeadings/Integration.Tests.ps1
@@ -35,8 +35,3 @@ Describe "Integration Test to ensure PowerShell 7 Native Multi-Line Code Example
     }
 }
 
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-#        Remove-Item $test.TempFolder -Recurse -Force
-    }
-}

--- a/Tests/Integration/SeparateMarkdownHeadings/README.md
+++ b/Tests/Integration/SeparateMarkdownHeadings/README.md
@@ -5,7 +5,7 @@ This test ensures that this function:
 - Only matches valid markdown headings (and thus with no blank line beneath them)
 - Inserts a blank line beneath those heading matches
 
-Additional information:
+## Additional information:
 
 - [Markdownlint rule MD022](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md022---headers-should-be-surrounded-by-blank-lines)
 - Link to regex in function [source file](https://github.com/alt3/Docusaurus.PowerShell/blob/main/Source/Private/SeparateMarkdownHeadings.ps1#L12)


### PR DESCRIPTION
No longer deletes the PlatyPS and mdx files found in `$env:Temp` for the test module after running tests to make debugging a lot easier (no more need to disable `AfterAll` in the tests).