### PR TITLE
Make unit tests truly unit tests

### DIFF
--- a/Tests/Integration/Bootstrap.ps1
+++ b/Tests/Integration/Bootstrap.ps1
@@ -1,6 +1,6 @@
 <#
     .SYNOPSIS
-    DRY helper for logic shared by all tests.
+    DRY helper for logic shared by all integration tests.
 
     .NOTES
     Every integration test follows the same logic:

--- a/Tests/Unit/Bootstrap.ps1
+++ b/Tests/Unit/Bootstrap.ps1
@@ -1,0 +1,35 @@
+<#
+    .SYNOPSIS
+    DRY helper for logic shared by all unit tests.
+
+    .NOTES
+    Every unit test follows the same logic:
+    - Dot sources the source file belonging to the test
+    - Mocks whatever commands are not relevant
+    - Tests the imported function
+
+#>
+param(
+    [Parameter(Mandatory = $True)][System.IO.FileInfo]$TestFolder
+)
+
+$test = @{
+    Name   = $TestFolder.Name.Replace(".Tests.ps1", "") # e.g. GetCustomEditUrl
+    Folder = $TestFolder.Directory.FullName
+    Type   = $TestFolder.Directory.Name # e.g. Private or Public
+    TempFolder = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $TestFolder.Name.Replace(".Tests.ps1", "")
+}
+
+# find the correlating source file
+$test.SourceFile = Join-Path -Path $TestFolder.Directory.Parent.Parent.Parent -ChildPath "Source" |
+Join-Path -ChildPath $test.Type |
+Join-Path -ChildPath "$($test.Name).ps1"
+
+# dot source the source file
+. $test.SourceFile
+
+# remove previous folder in $env:Temp
+if (Test-Path -Path $test.TempFolder) {
+    Remove-Item $test.TempFolder -Recurse -Force
+}
+

--- a/Tests/Unit/Private/GetCustomEditUrl.Tests.ps1
+++ b/Tests/Unit/Private/GetCustomEditUrl.Tests.ps1
@@ -1,92 +1,52 @@
-BeforeDiscovery {
-    if (-not(Get-Module Alt3.Docusaurus.PowerShell)) {
-        throw "Required module 'Alt3.Docusaurus.Powershell' is not loaded."
-    }
-}
-
 BeforeAll {
-    # create dummy markdown file for this test
-    $markdownFilePath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'Dummy-Command.md'
-    "Dummy markdown for testing GetCustomEditUrl" | Out-File -FilePath $markdownFilePath
-    $markdownFile = Get-Item -Path $markdownFilePath
+    . "$((Get-Item -Path $PSCommandPath).Directory.Parent.FullName)/Bootstrap.ps1" -TestFolder (Get-Item -Path $PSCommandPath)
 
-    # create dummy module for this test
-    $modulePath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath 'DummyModule.psm1'
-    "Dummy markdown for testing GetCustomEditUrl" | Out-File -FilePath $modulePath
-    $module = Get-Item -Path $modulePath
+    $DummyMarkdownFile = New-Item -Path (Join-Path $test.TempFolder -ChildPath "Get-DummyCommand.md") -Force
+    $DummyModuleFile = New-Item -Path (Join-Path $test.TempFolder -ChildPath "DummyModule.md") -Force
 }
 
 Describe "Unit test for private function GetCustomEditUrl" {
-    It "Dummy markdown file created for test should exist" {
-        $markdownFilePath | Should -Exist
-    }
-
-    It "Dummy module created for test should exist" {
-        $modulePath | Should -Exist
-    }
-
     It "Returns `$null when omitting optional argument -EditUrl" {
-        InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile } {
-            GetCustomEditUrl -Module "DummyModule" -MarkdownFile $MarkdownFile | Should -BeNullOrEmpty
-        }
+        GetCustomEditUrl -Module "DummyModule" -MarkdownFile $DummyMarkdownFile | Should -BeNullOrEmpty
     }
 
     It "Returns string ""null"" when using -EditUrl ""null""" {
-        InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile } {
-            GetCustomEditUrl -Module "DummyModule" -MarkdownFile $markdownFile -EditUrl "null" | Should -Be "null"
-        }
+        GetCustomEditUrl -Module "DummyModule" -MarkdownFile $DummyMarkdownFile -EditUrl "null" | Should -Be "null"
     }
 
     It "Produces the correct URL when passing no trailing slash" {
-        InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile } {
-            GetCustomEditUrl -Module "DummyModule" -MarkdownFile $markdownFile -EditUrl "https://without.slash.com" |
-            Should -Be "https://without.slash.com/Dummy-Command.ps1"
-        }
+
+        GetCustomEditUrl -Module "DummyModule" -MarkdownFile $DummyMarkdownFile -EditUrl "https://without.slash.com" |
+        Should -Be "https://without.slash.com/Get-DummyCommand.ps1"
     }
 
     It "Produces the correct URL when passing a single trailing slash" {
-        InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile } {
-            GetCustomEditUrl -Module "DummyModule" -MarkdownFile $markdownFile -EditUrl "https://with.slash.com/" |
-            Should -Be "https://with.slash.com/Dummy-Command.ps1"
-        }
+        GetCustomEditUrl -Module "DummyModule" -MarkdownFile $DummyMarkdownFile -EditUrl "https://with.slash.com/" |
+        Should -Be "https://with.slash.com/Get-DummyCommand.ps1"
     }
 
     It "Produces the correct URL when passing multiple trailing slashes" {
-        InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile } {
-            GetCustomEditUrl -Module "DummyModule" -MarkdownFile $markdownFile -EditUrl "https://with.slashes.com//" |
-            Should -Be "https://with.slashes.com/Dummy-Command.ps1"
-        }
+        GetCustomEditUrl -Module "DummyModule" -MarkdownFile $DummyMarkdownFile -EditUrl "https://with.slashes.com//" |
+        Should -Be "https://with.slashes.com/Get-DummyCommand.ps1"
     }
 
     Context "when not using -Monolithic" {
-        It "Uses markdown file name to generate URL pointing to the correlating .ps1 (function) source file" {
-            InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile } {
-                GetCustomEditUrl -Module "DummyModule" -MarkdownFile $markdownFile -EditUrl "https://site.com" |
-                Should -Be "https://site.com/Dummy-Command.ps1"
-            }
+        It "Uses markdown file name to generate URL pointing to the correlating .ps1 (function/command) source file" {
+            GetCustomEditUrl -Module "DummyModule" -MarkdownFile $DummyMarkdownFile -EditUrl "https://site.com" |
+            Should -Be "https://site.com/Get-DummyCommand.ps1"
         }
     }
 
     Context "when using -Monolithic" {
-        It "Uses markdown file name to generate URL pointing to the correlating .psm1 (module) source file" {
-            InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile; Module = $module } {
-                GetCustomEditUrl -Module $module -MarkdownFile $markdownFile -EditUrl "https://site.com" -Monolithic |
-                Should -Be "https://site.com/DummyModule.psm1"
-            }
+        It "Uses the module file name without extension to generate URL pointing to the correlating .psm1 (module) source file" {
+            GetCustomEditUrl -Module $DummyModuleFile -MarkdownFile $DummyMarkdownFile -EditUrl "https://site.com" -Monolithic |
+            Should -Be "https://site.com/DummyModule.psm1"
         }
 
-        It "Otherwise simply uses the passed module name to generate URL pointing to the correlating .psm1 (module) source file" {
-            InModuleScope Alt3.Docusaurus.Powershell -Parameters @{MarkdownFile = $markdownFile; Module = $module } {
-                GetCustomEditUrl -Module Microsoft.PowerShell.Management -MarkdownFile $markdownFile -EditUrl "https://site.com" -Monolithic |
-                Should -Be "https://site.com/Microsoft.PowerShell.Management.psm1"
-            }
+        It "Otherwise simply uses the passed module name string to generate URL pointing to the correlating .psm1 (module) source file" {
+            GetCustomEditUrl -Module Microsoft.PowerShell.Management -MarkdownFile $DummyMarkdownFile -EditUrl "https://site.com" -Monolithic |
+            Should -Be "https://site.com/Microsoft.PowerShell.Management.psm1"
         }
     }
 }
 
-AfterAll {
-    if (Get-Module Alt3.Docusaurus.PowerShell) {
-        Remove-Item -Path $markdownFilePath
-        Remove-Item -Path $modulePath
-    }
-}

--- a/build-module.ps1
+++ b/build-module.ps1
@@ -61,10 +61,6 @@ $configuration.TestResult.Enabled = $true
 $configuration.TestResult.OutputPath = Join-Path -Path "Output" -ChildPath "Pester" | Join-Path -ChildPath "TestResults.xml"
 $configuration.TestResult.OutputFormat = "NUnitXml"
 
-if ($PassThru) {
-    $configuration.Run.PassThru = $true
-}
-
 if ($Coverage) {
     $configuration.CodeCoverage.Enabled = $true
     $configuration.CodeCoverage.Path = $latestModulePath
@@ -73,6 +69,10 @@ if ($Coverage) {
     $configuration.CodeCoverage.OutputFormat = 'JaCoCo'
 
     $configuration.CodeCoverage.CoveragePercentTarget = 80 # minimum threshold needed to pass
+}
+
+if ($PassThru) {
+    $configuration.Run.PassThru = $true
 }
 
 Invoke-Pester -Configuration $configuration


### PR DESCRIPTION
Were previously running as integration tests.

FYI this breaks code coverage because unit tests are not run against the compiled module (whereas the integration tests do)