### PR TITLE
Fix broken test for C:\>

### DIFF
--- a/Tests/Integration/CrossVersionCodeExamples/Expected.mdx
+++ b/Tests/Integration/CrossVersionCodeExamples/Expected.mdx
@@ -194,8 +194,8 @@ It should also unescape properly in the description and thus:
 
 - unescaped `backticks`
 - fully functioning [links](https://www.google.com)
-- use of the prompt directly: PS C:\> Get-ChildItem
-- use of the prompt backtick-enclosed: `PS C:\> Get-ChildItem`
+- use of the prompt directly: PS C:\\&gt; Get-ChildItem
+- use of the prompt backtick-enclosed: `PS C:> Get-ChildItem`
 
 ### EXAMPLE 18
 


### PR DESCRIPTION
Still needs to be fixed properly, just updated the expected mdx fixture so tests do not break the ci release.