### PR TITLE
[WIPAdd GroupByVerb parameter and behaviours.

### DIFF
--- a/Source/Private/CreateOrCleanFolder.ps1
+++ b/Source/Private/CreateOrCleanFolder.ps1
@@ -4,7 +4,8 @@ function CreateOrCleanFolder() {
             Helper function to create a folder OR remove it's contents if it already exists.
     #>
     param(
-        [Parameter(Mandatory = $True)][string]$Path
+        [Parameter(Mandatory = $True)][string]$Path,
+        [switch]$GroupByVerb
     )
 
     GetCallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
@@ -19,5 +20,9 @@ function CreateOrCleanFolder() {
 
     # otherwise remove it's contents
     Write-Verbose "=> cleaning folder $($Path)"
-    Remove-Item -Path (Join-Path -Path $Path -ChildPath *.*)
+    if ($GroupByVerb) {
+        Remove-Item -Path (Join-Path -Path $Path -ChildPath */*.*)
+    } else {
+        Remove-Item -Path (Join-Path -Path $Path -ChildPath *.*)
+    }
 }


### PR DESCRIPTION
This adds a `-GroupByVerb` parameter and associated functionality including:

- Splits the markdown files into subfolders by approved PowerShell verb.
- Alters folder cleaning to remove 