### PR TITLE
ci: use poshcode/actions main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build module
       id: build
-      uses: PoshCode/actions/build-module@v1
+      uses: PoshCode/actions/build-module@main
       with:
         path: ${{github.workspace}}/Source
         version: ${{ steps.gitversion.outputs.LegacySemVerPadded }}
@@ -136,7 +136,7 @@ jobs:
       with:
         dataFile: ${{github.workspace}}/RequiredModules/RequiredModules.psd1 # downloaded artifact path
 
-    - uses: PoshCode/Actions/pester@v1
+    - uses: PoshCode/Actions/pester@main
       with:
         pesterVersion: 5.6.0
         codeCoveragePath: Modules/${{env.MODULE_NAME}}


### PR DESCRIPTION
Because there is no @v2 to use and we need to fix deprecated `Set-Output` ci warnings.